### PR TITLE
Replace uninformative link texts

### DIFF
--- a/episodes/01_introduction.Rmd
+++ b/episodes/01_introduction.Rmd
@@ -13,7 +13,7 @@ exercises: 2
 
 ::::::::::::::::::::::::::::::::::::: objectives
 
-- Explain the difference between a relational database and a spreadsheet?
+- Explain the difference between a relational database and a spreadsheet
 - Explain the advantages and disadvantages
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
@@ -24,12 +24,12 @@ exercises: 2
 
 ### First exploration of features
 
-For a first impression of what is possible with NocoDB, follow this [link](https://nocodb.adwmainz.net/dashboard/#/nc/form/d656e550-a93d-4ec7-94d8-27a7ebd1d5bc) and fill out the form.
+For a first impression of what is possible with NocoDB, [add a review of a painting](https://nocodb.adwmainz.net/dashboard/#/nc/form/d656e550-a93d-4ec7-94d8-27a7ebd1d5bc).
 
 1. Look for your favorite painting and put all the metadata and the painting into the form
-2. Follow this [link](https://nocodb.adwmainz.net/dashboard/#/nc/view/bd933a32-50af-47c7-a99a-1ca46af450aa), enter the password "NocoDB_Carpentry" and watch the database growing
-3. Now you can open the database with this [link](https://nocodb.adwmainz.net/dashboard/#/base/8b791733-2258-45b4-94c7-b954f7b21528) and change records, if you did any mistake
-4. Finally, you can now view a gallery of all the images with metadata in the database at the following [link](https://nocodb.adwmainz.net/dashboard/#/nc/gallery/a3094f97-80f6-491a-86d4-fc6613b41a01)
+2. Open the [tabular results view](https://nocodb.adwmainz.net/dashboard/#/nc/view/bd933a32-50af-47c7-a99a-1ca46af450aa), enter the password "NocoDB_Carpentry" and watch the database grow
+3. Open the [database management interface](https://nocodb.adwmainz.net/dashboard/#/base/8b791733-2258-45b4-94c7-b954f7b21528) and change records, if you made any mistake
+4. Finally, you can now view a [gallery of all the images with metadata in the database](https://nocodb.adwmainz.net/dashboard/#/nc/gallery/a3094f97-80f6-491a-86d4-fc6613b41a01)
 
 If everything went right, we filled a database with different paintings from different artists with a form in NocoDB without even creating accounts for everyone.
 


### PR DESCRIPTION
The first exploration of features has four different links, but they all use `link` as the link text. This makes the page less accessible. I replaced 'link' with a concise description of the link target.

I also removed the question mark from the first objective. I don't know what changed in the lorem ipsum text, but I don't think it matters.